### PR TITLE
Reconfigure CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ cmake_install.cmake
 *.so
 *.dll
 
-# Catch2 testing reports
-Testing/
-CTestTestfile.cmake
+# Misc
+.vscode
+.vs
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,8 @@ target_include_directories(
 
 target_include_directories(
   all_tests PRIVATE
-  ${CMAKE_SOURCE_DIR}/include    # Allows `#include <search/searcher.h>`
-  ${CMAKE_SOURCE_DIR}/tests/mock # Allows `#include "MockDatabase.h"`
+  ${CMAKE_SOURCE_DIR}/include
+  ${CMAKE_SOURCE_DIR}/tests/mock
 )
 
 # Link the test executable to SearchRPI and GTest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,27 +1,16 @@
-# Minimum CMake version
 cmake_minimum_required(VERSION 3.14)
 
-# Project name and version
 project(SearchRPI VERSION 1.0)
-
-# Enable testing
-# include(CTest)
-
-# Add the main program
-# add_executable(my_program src/main.cpp)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-include(FetchContent)
-# Fetch Snowball library
-FetchContent_Declare(
-    snowball
-    GIT_REPOSITORY https://github.com/snowballstem/snowball.git
-    GIT_TAG master
-)
-FetchContent_MakeAvailable(snowball)
+enable_testing()
 
+# Add the include directory (avoids needing relative paths)
+include_directories(${CMAKE_SOURCE_DIR}/include)
+
+include(FetchContent)
 FetchContent_Declare(
   googletest
   URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
@@ -30,27 +19,37 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
-enable_testing()
+# Find all source files in the src directory
+file(GLOB_RECURSE SRC_FILES ${CMAKE_SOURCE_DIR}/src/*.cc)
 
 # Find all test source files in the tests directory
-file(GLOB TEST_SOURCES "tests/*.cc")
-file(GLOB QUERY_PROCESSING_SOURCES "src/*.cpp" "src/*.cc")
+file(GLOB_RECURSE TEST_FILES ${CMAKE_SOURCE_DIR}/tests/*.cc)
+
+# Create a library from source files
+add_library(SearchRPI ${SRC_FILES})
 
 # Create an executable for all tests
-add_executable(
-  all_tests
-  ${TEST_SOURCES}
-  ${QUERY_PROCESSING_SOURCES}
+add_executable(all_tests ${TEST_FILES})
+
+target_include_directories(
+  SearchRPI PUBLIC
+  ${CMAKE_SOURCE_DIR}/include
+  ${CMAKE_SOURCE_DIR}/src
 )
 
 target_include_directories(
   all_tests PRIVATE
-  src
+  ${CMAKE_SOURCE_DIR}/include    # Allows `#include <search/searcher.h>`
+  ${CMAKE_SOURCE_DIR}/tests/mock # Allows `#include "MockDatabase.h"`
 )
-# Link GTest library
+
+# Link the test executable to SearchRPI and GTest
 target_link_libraries(
-  all_tests
+  all_tests PRIVATE
+  SearchRPI
   GTest::gtest_main
+  GTest::gmock
+  GTest::gmock_main
 )
 
 # Include GoogleTest and discover all tests

--- a/README.md
+++ b/README.md
@@ -2,3 +2,22 @@
 
 This repository contains the core components of SearchRPI, responsible for handling the user-facing functionality of the search engine. It integrates all the essential systems required to deliver relevant and ranked search results to users.
 
+## Getting Started
+
+1. **Clone the repository:**
+    ```bash
+    git clone https://github.com/SearchRPI/Search.git
+    cd Search
+    ```
+
+2. **Build the project:**
+    ```bash
+    mkdir build && cd build
+    cmake ..
+    make
+    ```
+
+5. **Run tests:**
+    ```bash
+    ./all_tests
+    ```


### PR DESCRIPTION
Reconfigured CMake to not require relative includes. Also:
- Added GMock
- Removed Snowball
- Added common config folders to .gitignore
- Added short setup to README