### PR TITLE
Doxygen -> GitHub Pages

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-
   workflow_dispatch:
 
 jobs:
@@ -15,25 +14,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Update package lists
-        run: sudo apt-get update
-
-      - name: Install Doxygen if not installed
-        run: |
-          if ! command -v doxygen &> /dev/null
-          then
-              echo "Doxygen not found. Installing..."
-              sudo apt-get install -y doxygen graphviz
-          else
-              echo "Doxygen is already installed."
-          fi
-
       - name: Set up Doxygen
         uses: mattnotmitt/doxygen-action@v1.9.8
 
-      - name: Generate Doxygen documentation
+      - name: Generate Doxygen Docs
         run: |
-          doxygen -d WARNING Doxyfile || true
+          doxygen Doxyfile
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,0 +1,43 @@
+name: Generate Doxygen Docs
+
+on:
+  push:
+    branches:
+      - "main"
+
+  workflow_dispatch:
+
+jobs:
+  generate-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Update package lists
+        run: sudo apt-get update
+
+      - name: Install Doxygen if not installed
+        run: |
+          if ! command -v doxygen &> /dev/null
+          then
+              echo "Doxygen not found. Installing..."
+              sudo apt-get install -y doxygen graphviz
+          else
+              echo "Doxygen is already installed."
+          fi
+
+      - name: Set up Doxygen
+        uses: mattnotmitt/doxygen-action@v1.9.8
+
+      - name: Generate Doxygen documentation
+        run: |
+          doxygen -d WARNING Doxyfile || true
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./docs

--- a/Doxyfile
+++ b/Doxyfile
@@ -1184,7 +1184,7 @@ GENERATE_HTML          = YES
 # The default directory is: html.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_OUTPUT            = html
+HTML_OUTPUT            = .
 
 # The HTML_FILE_EXTENSION tag can be used to specify the file extension for each
 # generated HTML page (for example: .htm, .php, .asp).

--- a/Doxyfile
+++ b/Doxyfile
@@ -467,7 +467,7 @@ LOOKUP_CACHE_SIZE      = 0
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = NO
+EXTRACT_ALL            = YES
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.
@@ -829,7 +829,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = src
+INPUT                  = include src
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
Automatically runs Doxygen and writes docs to gh-pages branch (where github pages will be set to look for index.html)

Also fixed some issues with the Doxyfile config, all files are now detected and correctly put into `/docs`